### PR TITLE
Delete all manual overlays

### DIFF
--- a/window-close.go
+++ b/window-close.go
@@ -139,10 +139,10 @@ func CloseWindow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if state.Overlay != nil {
-		// If heating was turned off manually, we assume it was turned off
+		// If heating was controlled manually, we assume it was controlled
 		// because of an open window. We can therefore return to normal heating
 		// when the window is closed.
-		if state.Overlay.Type == "MANUAL" && state.Overlay.Setting.Power == "OFF" {
+		if state.Overlay.Type == "MANUAL" {
 			if err := gotado.DeleteZoneOverlay(tadoClient, userHome, zone); err != nil {
 				log.Printf("Failed to delete manual tado° zone overlay: %v", err)
 				httpError(w, http.StatusInternalServerError)


### PR DESCRIPTION
Before this fix we only removed an overlay when it turned off heating.
This PR adapts this behaviour to delete all manual overlays, regardless if heating was manually turned off or on.