### PR TITLE
Read tado client id and secret from env vars

### DIFF
--- a/window-close.go
+++ b/window-close.go
@@ -14,8 +14,6 @@ import (
 const (
 	secretTadoUsername = "tado_username"
 	secretTadoPassword = "tado_password"
-	tadoClientID       = "tado-web-app"
-	tadoClientSecret   = "wZaRN7rpjn3FoNyF5IFuxg9uMzYJcvOoQ8QWiIqS3hfk6gLhVlG57j5YNoZL2Rtc"
 )
 
 // TadoWindowCloseAction holds tado° zone in which a window was closed
@@ -52,6 +50,18 @@ func CloseWindow(w http.ResponseWriter, r *http.Request) {
 	projectID, ok := os.LookupEnv("GCP_PROJECT")
 	if !ok {
 		log.Println("Missing environment variable 'GCP_PROJECT'")
+		httpError(w, http.StatusInternalServerError)
+		return
+	}
+	tadoClientID, ok := os.LookupEnv("TADO_CLIENT_ID")
+	if !ok {
+		log.Println("Missing environment variable 'TADO_CLIENT_ID'")
+		httpError(w, http.StatusInternalServerError)
+		return
+	}
+	tadoClientSecret, ok := os.LookupEnv("TADO_CLIENT_SECRET")
+	if !ok {
+		log.Println("Missing environment variable 'TADO_CLIENT_SECRET'")
 		httpError(w, http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
The tado client id and secret are static values published by tado. Therefore they were added here in the code as normal constants.

Even though they are static and publicly shared by tado, it is still better to make them configurable via environment variables.

Fix #25.