### PR TITLE
Trigger deploy action after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,5 +12,6 @@ jobs:
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2.29
         with:
+          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           release-type: simple
           package-name: tado-window-control


### PR DESCRIPTION
In order to trigger new workflow runs from a Github action, the action
must use a personal access token for authentication. See [1] for more
information. Using a PAT for release-please should therefore allow to
automatically trigger the deploy action after a new release was created.

Fixes #30 

[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token