### PR TITLE
Fix wrong loop variable dereferencing

### DIFF
--- a/window-close.go
+++ b/window-close.go
@@ -116,6 +116,7 @@ func CloseWindow(w http.ResponseWriter, r *http.Request) {
 	var userHome *gotado.UserHome
 	for _, h := range user.Homes {
 		if h.Name == action.HomeName {
+			h := h
 			userHome = &h
 			break
 		}


### PR DESCRIPTION
When dereferencing loop variables in go, one must ensure to copy the value
in the loop variable before dereferencing. Else one dereferences the
loop pointer instead of the variable. See [1] for more details.

[1]: https://stackoverflow.com/questions/45967305/copying-the-address-of-a-loop-variable-in-go
