### PR TITLE
Split Release Please action into two jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,17 @@ on:
       - main
 
 jobs:
+  release-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        with:
+          release-type: go
+          package-name: tado-window-control
+          command: release-pr
   release:
-    name: Release Please
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
@@ -15,3 +24,4 @@ jobs:
           token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           release-type: go
           package-name: tado-window-control
+          command: github-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v3
         with:
           token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
-          release-type: simple
+          release-type: go
           package-name: tado-window-control


### PR DESCRIPTION
Run Release Please in two jobs with different tokens.

See commit description for more information.

Fix #60
