### PR TITLE
Switch deploy authentication to Workload Identity Federation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,14 +10,20 @@ jobs:
   deploy:
     name: Cloud Function
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - uses: actions/checkout@v3
+      - uses: "google-github-actions/auth@v0"
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
       - uses: google-github-actions/deploy-cloud-functions@v0.10.0
         with:
           name: tado-window-close
           runtime: go116
           entry_point: CloseWindow
-          credentials: ${{ secrets.GCP_SA_KEY }}
           region: ${{ secrets.GCP_REGION }}
           env_vars: GCP_PROJECT=${{ secrets.GCP_PROJECT_ID }},TADO_CLIENT_ID=${{ secrets.TADO_CLIENT_ID }},TADO_CLIENT_SECRET=${{ secrets.TADO_CLIENT_SECRET }}
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}


### PR DESCRIPTION
Authentication via long living secret tokens is now deprecated and
should be replaced by Workload Identity Federation.

See
https://github.com/google-github-actions/deploy-cloud-functions#authorization
for more information.

Fix #62
