### PR TITLE
Set go toolchain patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gonzolino/tado-window-control
 
-go 1.21
+go 1.21.13
 
 require (
 	cloud.google.com/go/secretmanager v1.14.3


### PR DESCRIPTION
CodeQL warns that the go toolchain version should contain the patch version.
